### PR TITLE
Fix IndexOutOfBounds exception when importing certain OBJs

### DIFF
--- a/src/main/java/tileset/Tile.java
+++ b/src/main/java/tileset/Tile.java
@@ -599,24 +599,20 @@ public class Tile {
             if (index == -1) {
                 ArrayList<Face> fIndsQuad = new ArrayList<>();
                 ArrayList<Face> fIndsTri = new ArrayList<>();
-                for (int j = 0; j < fIndsQuadArray.get(i).size(); j++) {
-                    fIndsQuad.add(fIndsQuadArray.get(i).get(j));
-                }
-                for (int j = 0; j < fIndsTriArray.get(i).size(); j++) {
-                    fIndsTri.add(fIndsTriArray.get(i).get(j));
-                }
+                if (i < fIndsQuadArray.size())
+                    fIndsQuad.addAll(fIndsQuadArray.get(i));
+                if (i < fIndsTriArray.size())
+                    fIndsTri.addAll(fIndsTriArray.get(i));
                 fIndsQuadArrayFixed.add(fIndsQuad);
                 fIndsTriArrayFixed.add(fIndsTri);
                 textureIDsFixed.add(id);
             } else {
                 ArrayList<Face> fIndsQuad = fIndsQuadArrayFixed.get(index);
                 ArrayList<Face> fIndsTri = fIndsTriArrayFixed.get(index);
-                for (int j = 0; j < fIndsQuadArray.get(i).size(); j++) {
-                    fIndsQuad.add(fIndsQuadArray.get(i).get(j));
-                }
-                for (int j = 0; j < fIndsTriArray.get(i).size(); j++) {
-                    fIndsTri.add(fIndsTriArray.get(i).get(j));
-                }
+                if (i < fIndsQuadArray.size())
+                    fIndsQuad.addAll(fIndsQuadArray.get(i));
+                if (i < fIndsTriArray.size())
+                    fIndsTri.addAll(fIndsTriArray.get(i));
             }
         }
         textureIDs = textureIDsFixed;


### PR DESCRIPTION
When trying to import OBJs made from Blockbench, it causes an IndexOutOfBoundsException. This PR fixes that IOOBE by making sure the index does not exceed the size of the array but does not add any special handling for the models to make them work, they seem to work fine.

I exported a tile from one of the default tilesets, imported it into Blockbench, exported it as an OBJ, and then imported it back into PDSMS with no other changes to test. I have not tested this with other types of OBJs that have failed to import in the past

Before
<img width="1114" height="628" alt="image" src="https://github.com/user-attachments/assets/117bca89-15ce-4de9-a1d9-7b6822533f5b" />
After
<img width="611" height="475" alt="image" src="https://github.com/user-attachments/assets/f1a351dd-5d60-48cc-8ea5-5a5c899fa5ef" />
