### PR TITLE
Clarify backsound names

### DIFF
--- a/src/main/java/formats/backsound/BacksoundEditorDialog.jfd
+++ b/src/main/java/formats/backsound/BacksoundEditorDialog.jfd
@@ -117,23 +117,23 @@ new FormModel {
 				add( new FormComponent( "javax.swing.JComboBox" ) {
 					name: "jcbSoundType"
 					"model": new javax.swing.DefaultComboBoxModel {
-						selectedItem: "Water flow"
-						addElement( "Water flow" )
-						addElement( "Wind turbine" )
-						addElement( "Sea waves" )
-						addElement( "Silence 1" )
+						selectedItem: "Water Flow"
+						addElement( "Water Flow" )
+						addElement( "Windmill" )
+						addElement( "Seashore" )
+						addElement( "Pillar" )
 						addElement( "Whirlpool" )
-						addElement( "Strong water current" )
-						addElement( "Silence 2" )
-						addElement( "Stadium chant" )
-						addElement( "Ship horn" )
-						addElement( "Silence 3" )
-						addElement( "Sea wave 2" )
-						addElement( "Bells " )
-						addElement( "Wind" )
-						addElement( "Silence 4" )
-						addElement( "Unknown" )
-						addElement( "Synth horn" )
+						addElement( "Waterfall" )
+						addElement( "Lava" )
+						addElement( "Stadium Chant" )
+						addElement( "Steam Whistle" )
+						addElement( "Snorlax's Snoring" )
+						addElement( "Motor" )
+						addElement( "Bells" )
+						addElement( "Strong Wind" )
+						addElement( "Engine" )
+						addElement( "Fountain" )
+						addElement( "Electric Barrier" )
 					}
 					auxiliary() {
 						"JavaCodeGenerator.typeParameters": "String"


### PR DESCRIPTION
I'm not sure how the backsound names were determined for this fork... maybe by ear?

...but the actual ones were uncovered as part of my efforts to decomp the soundplate code: https://github.com/pret/pokeheartgold/pull/487

There's probably a lot more that the decomp can do for the backsound editor, but I'm not knowledgeable enough to say what needs to be done where. In theory a few limiters need to be removed from the source code that make it stop reading entries above the default 16, but after that it's fully capable of using any sound added to the soundplate table.